### PR TITLE
Feature/multi tag

### DIFF
--- a/theme/components/IssueFinder.abell
+++ b/theme/components/IssueFinder.abell
@@ -33,11 +33,16 @@
 </style>
 <script>
 let repos;
+
+function returnSearchLabels() {
+  return '"' + allLabels.join('", "') + '"';
+}
+
 function loadGithubIssues({definedLabel, res}) {
   repos = res.data;
-  let issueCards = `Showing issues with "${definedLabel}" label`;
+  let issueCards = `Showing issues with ${returnSearchLabels()} label`;
   for (const repoName of Object.keys(repos)) {
-    const issues = repos[repoName].issues.edges.filter(issue => issue.node.assignees.edges.length <= 0);
+    const issues = containsAll(allLabels, repos[repoName].issues.edges.filter(issue => issue.node.assignees.edges.length <= 0));    
     for (const issue of issues) {
       issueCards += `
         <div class="issue-card shadow">
@@ -57,7 +62,6 @@ function loadGithubIssues({definedLabel, res}) {
       `
     }
   }
-
   document.querySelector('#issue-container').innerHTML = issueCards;
 }
 
@@ -66,7 +70,7 @@ function fetchIssues(label) {
   const findIssues = (repoName) => `
     repository(name: "${repoName}", owner: "abelljs") {
       name
-      issues(last: 100, orderBy: {field: CREATED_AT, direction: DESC}, filterBy: {labels: "${label}", states: OPEN}) {
+      issues(last: 100, orderBy: {field: CREATED_AT, direction: DESC}, filterBy: {labels: ["${label}"], states: OPEN}) {
         edges {
           node {
             title
@@ -116,8 +120,25 @@ function fetchIssues(label) {
   })
 }
 
+function containsAll(labels, repos){ 
+  let output = new Set();
+  // Manually loop over repo's it's quicker than map
+  for(var i = 0; i < repos.length; i++) {
+    const item = repos[i].node.labels.nodes;
+    let s = [];
+    item.forEach(label => {
+      s.push(label.name);
+    });
+    if(labels.every(j => s.includes(j))) {
+      output.add(repos[i]);
+    }
+  }
+  return output;
+}
+
 const label = location.search.slice(location.search.indexOf('label=') + 6);
-fetchIssues(label || 'Hacktoberfest')
+const allLabels = label.split(',');
+fetchIssues(allLabels[0] || 'Hacktoberfest')
   .then(loadGithubIssues)
 </script>
 </AbellComponent>

--- a/theme/components/IssueFinder.abell
+++ b/theme/components/IssueFinder.abell
@@ -137,7 +137,10 @@ function containsAll(labels, repos){
 }
 
 const label = location.search.slice(location.search.indexOf('label=') + 6);
-const allLabels = label.split(',');
+let allLabels = label.split(',');
+if(!allLabels[0]) {
+  allLabels = ['Hacktoberfest'];
+}
 fetchIssues(allLabels[0] || 'Hacktoberfest')
   .then(loadGithubIssues)
 </script>


### PR DESCRIPTION
Fix issue #6 regarding the filters.
You can now filter on multiple queries.

Please note: GitHub graph API does not like the "AND" filter, so included a custom filter (made a manual loop for speed)

You can see the result in the attached screenshot.
It also still works for 1 query
<img width="704" alt="Screenshot 2020-10-02 at 10 13 30" src="https://user-images.githubusercontent.com/554874/94902499-8baf6580-0498-11eb-85bc-6e556535de43.png">
