### PR TITLE
fix: use a monospace font for code blocks

### DIFF
--- a/theme/[path]/index.abell
+++ b/theme/[path]/index.abell
@@ -67,8 +67,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  
-  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500&display=swap" rel="stylesheet">   
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono&family=DM+Sans&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ $root }}/static/styles/docs.css" />
   <title>{{ meta.title }} - {{ globalMeta.siteName }}</title>
 

--- a/theme/index.abell
+++ b/theme/index.abell
@@ -44,8 +44,7 @@
   <meta property="og:description" content="Abell - a JavaScript based static site generator to create markdown and configuration based websites" />
   <meta property="og:site_name" content="abelljs.org"/>
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
-
-  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500&display=swap" rel="stylesheet">   
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono&family=DM+Sans&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./static/styles/index.css">
   <title>Abell - a JavaScript based static site generator to create markdown and configuration based websites</title>
   

--- a/theme/static/styles/inlined/global.css.abell
+++ b/theme/static/styles/inlined/global.css.abell
@@ -9,7 +9,8 @@ body {
   --code-background: #f3f3f3;
   --footer-background: #f9f9f9;
   --link-color: #006EB8;
-  --font-family-primary: 'DM Sans', sans-serif;;
+  --font-family-primary: 'DM Sans', sans-serif;
+  --font-family-monospace: 'DM Mono', sans-serif;
   --abell-primary: #3354ea;
   --abell-secondary: #09239d;
 }
@@ -121,7 +122,7 @@ code {
   border-radius: 4px;
   word-spacing: 3px;
   font-size: smaller;
-  font-family: var(--font-family-primary);
+  font-family: var(--font-family-monospace);
 }
 
 code.hljs {


### PR DESCRIPTION
Using a monospace font for code blocks makes them more readable. 

This PR makes code blocks use the `DM Mono` font instead of `DM Sans` font.